### PR TITLE
Add readiness endpoint and return 503 while waiting for shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ PORT=8080 DUCKTAPE_LOG=debug go run cmd/main.go
 
 # Health check
 curl http://localhost:8080/health
+
+# Readiness check
+curl http://localhost:8080/ready
 ```
 
 Server runs on port 8080 by default.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,10 @@ import (
 	"golang.org/x/net/http2/h2c"
 )
 
-const defaultDrainDelay = 10 * time.Second
+const (
+	defaultDrainDelay = 10 * time.Second
+	shutdownTimeout   = 5 * time.Minute
+)
 
 func main() {
 	var level slog.Level
@@ -107,11 +110,9 @@ func main() {
 		}
 	}
 
-	const shutdownTimeout = 5 * time.Minute
-
 	api.SetDraining(true)
-	log.Printf("Received shutdown signal, entering drain period for %s", drainDelay)
 	if drainDelay > 0 {
+		log.Printf("Received shutdown signal, entering drain period for %s", drainDelay)
 		time.Sleep(drainDelay)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"log"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/artie-labs/ducktape/api/pkg/ducktape"
 	"github.com/artie-labs/ducktape/internal/api"
@@ -13,6 +18,8 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
+
+const defaultDrainDelay = 10 * time.Second
 
 func main() {
 	var level slog.Level
@@ -63,6 +70,58 @@ func main() {
 		MaxUploadBufferPerStream:     ducktape.RecommendedBufferSize * 4,  // 4 MB per stream
 	})
 
-	log.Printf("Starting server on port %s\n", port)
-	log.Fatal(http.ListenAndServe("0.0.0.0:"+port, h2cHandler))
+	api.SetDraining(false)
+	server := &http.Server{
+		Addr:    "0.0.0.0:" + port,
+		Handler: h2cHandler,
+	}
+
+	serverErrCh := make(chan error, 1)
+	go func() {
+		log.Printf("Starting server on port %s\n", port)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErrCh <- err
+		}
+	}()
+
+	signalContext, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	select {
+	case err := <-serverErrCh:
+		log.Fatal(err)
+	case <-signalContext.Done():
+	}
+
+	drainDelay := 0 * time.Second
+	if drainDelayEnv := os.Getenv("DUCKTAPE_DRAIN_DELAY"); drainDelayEnv != "" {
+		parsedDrainDelay, err := time.ParseDuration(drainDelayEnv)
+		if err != nil {
+			log.Printf("Invalid DUCKTAPE_DRAIN_DELAY=%q, using %s", drainDelayEnv, defaultDrainDelay)
+			drainDelay = defaultDrainDelay
+		} else if parsedDrainDelay < 0 {
+			log.Printf("Ignoring negative DUCKTAPE_DRAIN_DELAY=%q, using %s", drainDelayEnv, defaultDrainDelay)
+			drainDelay = defaultDrainDelay
+		} else {
+			drainDelay = parsedDrainDelay
+		}
+	}
+
+	const shutdownTimeout = 5 * time.Minute
+
+	api.SetDraining(true)
+	log.Printf("Received shutdown signal, entering drain period for %s", drainDelay)
+	if drainDelay > 0 {
+		time.Sleep(drainDelay)
+	}
+
+	shutdownContext, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := server.Shutdown(shutdownContext); err != nil {
+		log.Printf("Graceful shutdown failed: %v", err)
+		if closeErr := server.Close(); closeErr != nil {
+			log.Printf("Forced close failed: %v", closeErr)
+		}
+	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"sync/atomic"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -12,11 +13,26 @@ import (
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
+var draining atomic.Bool
+
+func SetDraining(v bool) {
+	draining.Store(v)
+}
 
 func RegisterHealthCheckRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK"))
+	})
+
+	mux.HandleFunc("GET /ready", func(w http.ResponseWriter, r *http.Request) {
+		if draining.Load() {
+			http.Error(w, "draining", http.StatusServiceUnavailable)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("READY"))
 	})
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches server lifecycle/shutdown behavior and readiness signaling, which can impact load balancers and in-flight requests if misconfigured. Changes are contained to startup/shutdown and a new health route.
> 
> **Overview**
> Adds a new `GET /ready` readiness endpoint that returns `503 Service Unavailable` with "draining" once the process enters shutdown.
> 
> Reworks `cmd/main.go` to run the HTTP server with signal handling and graceful shutdown: on `SIGTERM`/interrupt it sets a global draining flag, optionally waits for `DUCKTAPE_DRAIN_DELAY`, then calls `server.Shutdown` with a timeout (falling back to `server.Close` on failure). Documentation is updated to include the readiness check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 042108c864806d11e7fdb2075249003f36efa7d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->