### PR TITLE
Respect column order

### DIFF
--- a/api/pkg/ducktape/types.go
+++ b/api/pkg/ducktape/types.go
@@ -21,8 +21,8 @@ type QueryRequest struct {
 }
 
 type QueryResponse struct {
-	Rows  []map[string]any `json:"rows"`
-	Error *string          `json:"error"`
+	Rows  []any   `json:"rows"`
+	Error *string `json:"error"`
 }
 
 type ExecuteStatement struct {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/artie-labs/ducktape/api/pkg/ducktape"
+	"github.com/artie-labs/ducktape/internal/utils"
 	_ "github.com/duckdb/duckdb-go/v2"
 )
 
@@ -49,8 +50,10 @@ func TestQueryExecuteIntegration(t *testing.T) {
 			t.Fatalf("expected 1 row, got %d", len(result))
 		}
 
-		if result[0]["name"] != "test" {
-			t.Errorf("expected name='test', got %v", result[0]["name"])
+		obj := result[0].(*utils.OrderedMap)
+		name, _ := obj.Get("name")
+		if name != "test" {
+			t.Errorf("expected name='test', got %v", name)
 		}
 	})
 }

--- a/internal/api/append_test.go
+++ b/internal/api/append_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/artie-labs/ducktape/api/pkg/ducktape"
+	"github.com/artie-labs/ducktape/internal/utils"
 	_ "github.com/duckdb/duckdb-go/v2"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -63,8 +64,10 @@ func TestAppend(t *testing.T) {
 			t.Errorf("expected 3 rows in table, got %d", len(result))
 		}
 
-		if result[0]["name"] != "Alice" {
-			t.Errorf("expected first row name=Alice, got %v", result[0]["name"])
+		obj := result[0].(*utils.OrderedMap)
+		name, _ := obj.Get("name")
+		if name != "Alice" {
+			t.Errorf("expected first row name=Alice, got %v", name)
 		}
 	})
 
@@ -141,8 +144,10 @@ func TestAppend(t *testing.T) {
 			t.Fatalf("expected 1 row, got %d", len(result))
 		}
 
-		if result[0]["id"] != int32(1) {
-			t.Errorf("expected id=1, got %v", result[0]["id"])
+		obj := result[0].(*utils.OrderedMap)
+		id, _ := obj.Get("id")
+		if id != int32(1) {
+			t.Errorf("expected id=1, got %v", id)
 		}
 	})
 
@@ -179,12 +184,16 @@ func TestAppend(t *testing.T) {
 			t.Fatalf("failed to query: %v", err)
 		}
 
-		if result[0]["value"] != nil {
-			t.Errorf("expected NULL value, got %v", result[0]["value"])
+		obj0 := result[0].(*utils.OrderedMap)
+		value0, _ := obj0.Get("value")
+		if value0 != nil {
+			t.Errorf("expected NULL value, got %v", value0)
 		}
 
-		if result[1]["count"] != nil {
-			t.Errorf("expected NULL count, got %v", result[1]["count"])
+		obj1 := result[1].(*utils.OrderedMap)
+		count1, _ := obj1.Get("count")
+		if count1 != nil {
+			t.Errorf("expected NULL count, got %v", count1)
 		}
 	})
 
@@ -221,12 +230,16 @@ func TestAppend(t *testing.T) {
 			t.Fatalf("failed to query: %v", err)
 		}
 
-		if result[0]["active"] != true {
-			t.Errorf("expected active=true, got %v", result[0]["active"])
+		obj0 := result[0].(*utils.OrderedMap)
+		active0, _ := obj0.Get("active")
+		if active0 != true {
+			t.Errorf("expected active=true, got %v", active0)
 		}
 
-		if result[1]["verified"] != true {
-			t.Errorf("expected verified=true, got %v", result[1]["verified"])
+		obj1 := result[1].(*utils.OrderedMap)
+		verified1, _ := obj1.Get("verified")
+		if verified1 != true {
+			t.Errorf("expected verified=true, got %v", verified1)
 		}
 	})
 
@@ -357,9 +370,11 @@ func TestAppend(t *testing.T) {
 			t.Fatalf("failed to query: %v", err)
 		}
 
-		count, ok := result[0]["count"].(int64)
+		obj := result[0].(*utils.OrderedMap)
+		countVal, _ := obj.Get("count")
+		count, ok := countVal.(int64)
 		if !ok {
-			t.Fatalf("expected count to be int64, got %T", result[0]["count"])
+			t.Fatalf("expected count to be int64, got %T", countVal)
 		}
 
 		if count != 1000 {

--- a/internal/api/execute_test.go
+++ b/internal/api/execute_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/artie-labs/ducktape/api/pkg/ducktape"
+	"github.com/artie-labs/ducktape/internal/utils"
 	_ "github.com/duckdb/duckdb-go/v2"
 )
 
@@ -288,12 +289,16 @@ func TestExecute(t *testing.T) {
 			t.Errorf("expected 2 rows remaining, got %d", len(rows))
 		}
 
-		if rows[0]["status"] != "completed" {
-			t.Errorf("expected first row status='completed', got %v", rows[0]["status"])
+		obj0 := rows[0].(*utils.OrderedMap)
+		status0, _ := obj0.Get("status")
+		if status0 != "completed" {
+			t.Errorf("expected first row status='completed', got %v", status0)
 		}
 
-		if rows[1]["status"] != "completed" {
-			t.Errorf("expected second row status='completed', got %v", rows[1]["status"])
+		obj1 := rows[1].(*utils.OrderedMap)
+		status1, _ := obj1.Get("status")
+		if status1 != "completed" {
+			t.Errorf("expected second row status='completed', got %v", status1)
 		}
 	})
 

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -53,7 +53,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	slog.Debug("query results", slog.Any("rows", objects), slog.Duration("elapsed", time.Since(start)))
 }
 
-func Query(ctx context.Context, dsn string, request ducktape.QueryRequest) ([]map[string]any, error) {
+func Query(ctx context.Context, dsn string, request ducktape.QueryRequest) ([]any, error) {
 	connector, err := utils.NewConnector(ctx, dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start a SQL client for queries(%q): %w", "duckdb", err)

--- a/internal/api/query_test.go
+++ b/internal/api/query_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/artie-labs/ducktape/api/pkg/ducktape"
+	"github.com/artie-labs/ducktape/internal/utils"
 	_ "github.com/duckdb/duckdb-go/v2"
 )
 
@@ -54,12 +55,16 @@ func TestQuery(t *testing.T) {
 			t.Errorf("expected 3 rows, got %d", len(result))
 		}
 
-		if result[0]["name"] != "Alice" {
-			t.Errorf("expected first row name=Alice, got %v", result[0]["name"])
+		obj0 := result[0].(*utils.OrderedMap)
+		name0, _ := obj0.Get("name")
+		if name0 != "Alice" {
+			t.Errorf("expected first row name=Alice, got %v", name0)
 		}
 
-		if result[1]["id"] != int32(2) {
-			t.Errorf("expected second row id=2, got %v", result[1]["id"])
+		obj1 := result[1].(*utils.OrderedMap)
+		id1, _ := obj1.Get("id")
+		if id1 != int32(2) {
+			t.Errorf("expected second row id=2, got %v", id1)
 		}
 	})
 
@@ -76,8 +81,10 @@ func TestQuery(t *testing.T) {
 		}
 
 		for _, row := range result {
-			if row["active"] != true {
-				t.Errorf("expected active=true, got %v", row["active"])
+			obj := row.(*utils.OrderedMap)
+			active, _ := obj.Get("active")
+			if active != true {
+				t.Errorf("expected active=true, got %v", active)
 			}
 		}
 	})
@@ -95,8 +102,10 @@ func TestQuery(t *testing.T) {
 			t.Fatalf("expected 1 row, got %d", len(result))
 		}
 
-		if result[0]["name"] != "Bob" {
-			t.Errorf("expected name=Bob, got %v", result[0]["name"])
+		obj := result[0].(*utils.OrderedMap)
+		name, _ := obj.Get("name")
+		if name != "Bob" {
+			t.Errorf("expected name=Bob, got %v", name)
 		}
 	})
 
@@ -112,19 +121,16 @@ func TestQuery(t *testing.T) {
 			t.Errorf("expected 3 rows, got %d", len(result))
 		}
 
-		if len(result[0]) != 2 {
-			t.Errorf("expected 2 columns, got %d", len(result[0]))
-		}
-
-		if _, exists := result[0]["id"]; !exists {
+		obj := result[0].(*utils.OrderedMap)
+		if _, exists := obj.Get("id"); !exists {
 			t.Error("expected 'id' column to exist")
 		}
 
-		if _, exists := result[0]["name"]; !exists {
+		if _, exists := obj.Get("name"); !exists {
 			t.Error("expected 'name' column to exist")
 		}
 
-		if _, exists := result[0]["age"]; exists {
+		if _, exists := obj.Get("age"); exists {
 			t.Error("expected 'age' column to not exist")
 		}
 	})
@@ -141,9 +147,11 @@ func TestQuery(t *testing.T) {
 			t.Fatalf("expected 1 row, got %d", len(result))
 		}
 
-		count, ok := result[0]["count"].(int64)
+		obj := result[0].(*utils.OrderedMap)
+		countVal, _ := obj.Get("count")
+		count, ok := countVal.(int64)
 		if !ok {
-			t.Errorf("expected count to be int64, got %T", result[0]["count"])
+			t.Errorf("expected count to be int64, got %T", countVal)
 		}
 
 		if count != 3 {
@@ -176,12 +184,16 @@ func TestQuery(t *testing.T) {
 			t.Fatalf("expected 3 rows, got %d", len(result))
 		}
 
-		if result[0]["name"] != "Charlie" {
-			t.Errorf("expected first name=Charlie (age 35), got %v", result[0]["name"])
+		obj0 := result[0].(*utils.OrderedMap)
+		name0, _ := obj0.Get("name")
+		if name0 != "Charlie" {
+			t.Errorf("expected first name=Charlie (age 35), got %v", name0)
 		}
 
-		if result[2]["name"] != "Bob" {
-			t.Errorf("expected last name=Bob (age 25), got %v", result[2]["name"])
+		obj2 := result[2].(*utils.OrderedMap)
+		name2, _ := obj2.Get("name")
+		if name2 != "Bob" {
+			t.Errorf("expected last name=Bob (age 25), got %v", name2)
 		}
 	})
 
@@ -246,12 +258,16 @@ func TestQuery(t *testing.T) {
 			t.Fatalf("failed to query: %v", err)
 		}
 
-		if result[0]["value"] != nil {
-			t.Errorf("expected NULL value, got %v", result[0]["value"])
+		obj0 := result[0].(*utils.OrderedMap)
+		value0, _ := obj0.Get("value")
+		if value0 != nil {
+			t.Errorf("expected NULL value, got %v", value0)
 		}
 
-		if result[1]["value"] != "test" {
-			t.Errorf("expected value='test', got %v", result[1]["value"])
+		obj1 := result[1].(*utils.OrderedMap)
+		value1, _ := obj1.Get("value")
+		if value1 != "test" {
+			t.Errorf("expected value='test', got %v", value1)
 		}
 	})
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -13,7 +14,58 @@ import (
 	"github.com/duckdb/duckdb-go/v2"
 )
 
-func RowsToObjects(rows *sql.Rows) ([]map[string]any, error) {
+// OrderedMap preserves the insertion order of keys when marshaling to JSON
+type OrderedMap struct {
+	keys   []string
+	values map[string]any
+}
+
+// MarshalJSON marshals the map while preserving column order
+func (om *OrderedMap) MarshalJSON() ([]byte, error) {
+	var buf strings.Builder
+	buf.WriteString("{")
+	for i, key := range om.keys {
+		if i > 0 {
+			buf.WriteString(",")
+		}
+		// Marshal the key
+		keyJSON, _ := json.Marshal(key)
+		buf.Write(keyJSON)
+		buf.WriteString(":")
+		// Marshal the value
+		valueJSON, err := json.Marshal(om.values[key])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(valueJSON)
+	}
+	buf.WriteString("}")
+	return []byte(buf.String()), nil
+}
+
+// Set adds or updates a key-value pair while preserving order (only adds to order on first insert)
+func (om *OrderedMap) Set(key string, value any) {
+	if _, exists := om.values[key]; !exists {
+		om.keys = append(om.keys, key)
+	}
+	om.values[key] = value
+}
+
+// Get retrieves a value by key
+func (om *OrderedMap) Get(key string) (any, bool) {
+	val, ok := om.values[key]
+	return val, ok
+}
+
+// NewOrderedMap creates a new OrderedMap
+func NewOrderedMap() *OrderedMap {
+	return &OrderedMap{
+		keys:   []string{},
+		values: make(map[string]any),
+	}
+}
+
+func RowsToObjects(rows *sql.Rows) ([]any, error) {
 	defer rows.Close()
 
 	columns, err := rows.Columns()
@@ -21,7 +73,7 @@ func RowsToObjects(rows *sql.Rows) ([]map[string]any, error) {
 		return nil, err
 	}
 
-	var objects []map[string]any
+	var objects []any
 	for rows.Next() {
 		row := make([]any, len(columns))
 		rowPointers := make([]any, len(columns))
@@ -33,9 +85,9 @@ func RowsToObjects(rows *sql.Rows) ([]map[string]any, error) {
 			return nil, err
 		}
 
-		object := make(map[string]any)
+		object := NewOrderedMap()
 		for i, column := range columns {
-			object[column] = row[i]
+			object.Set(column, row[i])
 		}
 
 		objects = append(objects, object)

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -62,21 +62,28 @@ func TestRowsToObjects(t *testing.T) {
 			t.Errorf("expected 3 objects, got %d", len(objects))
 		}
 
-		if objects[0]["id"] != int32(1) {
-			t.Errorf("expected id=1, got %v", objects[0]["id"])
+		obj0 := objects[0].(*OrderedMap)
+		id0, _ := obj0.Get("id")
+		if id0 != int32(1) {
+			t.Errorf("expected id=1, got %v", id0)
 		}
-		if objects[0]["name"] != "Alice" {
-			t.Errorf("expected name=Alice, got %v", objects[0]["name"])
+		name0, _ := obj0.Get("name")
+		if name0 != "Alice" {
+			t.Errorf("expected name=Alice, got %v", name0)
 		}
-		if objects[0]["active"] != true {
-			t.Errorf("expected active=true, got %v", objects[0]["active"])
+		active0, _ := obj0.Get("active")
+		if active0 != true {
+			t.Errorf("expected active=true, got %v", active0)
 		}
 
-		if objects[1]["name"] != "Bob" {
-			t.Errorf("expected name=Bob, got %v", objects[1]["name"])
+		obj1 := objects[1].(*OrderedMap)
+		name1, _ := obj1.Get("name")
+		if name1 != "Bob" {
+			t.Errorf("expected name=Bob, got %v", name1)
 		}
-		if objects[1]["active"] != false {
-			t.Errorf("expected active=false, got %v", objects[1]["active"])
+		active1, _ := obj1.Get("active")
+		if active1 != false {
+			t.Errorf("expected active=false, got %v", active1)
 		}
 	})
 
@@ -128,11 +135,14 @@ func TestRowsToObjects(t *testing.T) {
 			t.Errorf("expected 1 object, got %d", len(objects))
 		}
 
-		if objects[0]["name"] != nil {
-			t.Errorf("expected name=nil, got %v", objects[0]["name"])
+		obj := objects[0].(*OrderedMap)
+		name, _ := obj.Get("name")
+		if name != nil {
+			t.Errorf("expected name=nil, got %v", name)
 		}
-		if objects[0]["age"] != nil {
-			t.Errorf("expected age=nil, got %v", objects[0]["age"])
+		age, _ := obj.Get("age")
+		if age != nil {
+			t.Errorf("expected age=nil, got %v", age)
 		}
 	})
 
@@ -162,8 +172,10 @@ func TestRowsToObjects(t *testing.T) {
 			t.Errorf("expected 3 objects, got %d", len(objects))
 		}
 
-		if objects[0]["value"] != int32(42) {
-			t.Errorf("expected value=42, got %v", objects[0]["value"])
+		obj := objects[0].(*OrderedMap)
+		value, _ := obj.Get("value")
+		if value != int32(42) {
+			t.Errorf("expected value=42, got %v", value)
 		}
 	})
 }
@@ -932,15 +944,16 @@ func TestConvertValueRoundTrip(t *testing.T) {
 			t.Fatalf("expected 1 row, got %d", len(objects))
 		}
 
-		if objects[0]["event_date"] == nil {
+		obj := objects[0].(*OrderedMap)
+		if eventDate, _ := obj.Get("event_date"); eventDate == nil {
 			t.Error("event_date should not be nil")
 		}
 
-		if objects[0]["event_timestamp"] == nil {
+		if eventTimestamp, _ := obj.Get("event_timestamp"); eventTimestamp == nil {
 			t.Error("event_timestamp should not be nil")
 		}
 
-		if objects[0]["event_time"] == nil {
+		if eventTime, _ := obj.Get("event_time"); eventTime == nil {
 			t.Error("event_time should not be nil")
 		}
 	})


### PR DESCRIPTION
I just added a few modifications so that the order of properties in the JSON return objects matches the column order given in the query as currently it sorts them alphabetically. This is important for numerous reasons but my main need currently is that I'm writing ODBC/JDBC drivers to wrap ducktape (I have reasons) and almost everything that would consume those expect column order to be respected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape/type of query results from `map[string]any` to an ordered JSON object, which is a breaking API change for any consumers relying on map access or the previous JSON encoding behavior.
> 
> **Overview**
> **Query results now preserve column order in JSON.** `RowsToObjects` no longer builds `map[string]any`; it builds an `OrderedMap` with a custom `MarshalJSON` that emits keys in the same order as `rows.Columns()`.
> 
> This propagates through the API surface by changing `Query` and `QueryResponse.Rows` from `[]map[string]any` to `[]any`, and updates integration/unit tests to assert values via `*utils.OrderedMap` rather than direct map indexing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05efb5b9371a8bb860b3a588c7b0fc18568f5536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->