### PR TITLE
Make Appender flush limits configurable and raise default flushBytesLimits to 32

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ Streams NDJSON data over HTTP/2. Each line is a `RowMessage` with a `rv` (row va
 
 - `PORT`: Server port (default: `8080`)
 - `DUCKTAPE_LOG`: Log level (`debug`, `info`, `warn`, `error`)
+- `DUCKTAPE_FLUSH_BYTES`: Max payload size the Appender buffers before flushing, in bytes (default: `33554432`, i.e. 32 MiB). Larger values amortise round-trip cost to remote destinations (e.g. MotherDuck) at the price of more in-process memory per stream.
+- `DUCKTAPE_FLUSH_ROWS`: Max rows the Appender buffers before flushing (default: `100000`).
+- `DUCKTAPE_SCANNER_BUFFER`: Max size of a single NDJSON line read by `bufio.Scanner`, in bytes (default: `4194304`, i.e. 4 MiB).
 
 ## Go client
 

--- a/internal/api/append.go
+++ b/internal/api/append.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/artie-labs/ducktape/api/pkg/ducktape"
@@ -16,10 +18,29 @@ import (
 	"github.com/duckdb/duckdb-go/v2"
 )
 
-const (
-	flushInterval   = 100_000
-	flushBytesLimit = 3 * 1024 * 1024 // 3MB - flush before reaching DuckDB's 4MB limit
+var (
+	// flushInterval is the maximum number of rows the Appender buffers before flushing.
+	// Tunable via DUCKTAPE_FLUSH_ROWS.
+	flushInterval = envIntDefault("DUCKTAPE_FLUSH_ROWS", 100_000)
+
+	// flushBytesLimit is the maximum payload size the Appender buffers before flushing.
+	// Tunable via DUCKTAPE_FLUSH_BYTES. Larger values amortise round-trip cost to remote
+	// destinations (e.g. MotherDuck) at the price of more in-process memory per stream.
+	flushBytesLimit = envIntDefault("DUCKTAPE_FLUSH_BYTES", 32*1024*1024)
+
+	// maxScannerBuffer caps the size of a single NDJSON line read by the bufio.Scanner.
+	// Tunable via DUCKTAPE_SCANNER_BUFFER.
+	maxScannerBuffer = envIntDefault("DUCKTAPE_SCANNER_BUFFER", 4*1024*1024)
 )
+
+func envIntDefault(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return fallback
+}
 
 func handleAppend(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
@@ -127,11 +148,9 @@ func Append(ctx context.Context, dsn string, database string, schema string, tab
 
 	// Stream NDJSON from request body
 	scanner := bufio.NewScanner(input)
-	// Increase buffer size to handle large rows (default is 64KB)
-	// Set to 4MB to accommodate very large JSON lines
-	maxBufferSize := 4 * 1024 * 1024 // 4MB
-	buf := make([]byte, 0, 64*1024)  // Initial buffer size
-	scanner.Buffer(buf, maxBufferSize)
+	// Per-line scanner buffer; tunable via DUCKTAPE_SCANNER_BUFFER for unusually wide rows.
+	buf := make([]byte, 0, 64*1024) // Initial buffer size
+	scanner.Buffer(buf, maxScannerBuffer)
 	var bytesSinceFlush uint64
 
 	for scanner.Scan() {
@@ -168,7 +187,7 @@ func Append(ctx context.Context, dsn string, database string, schema string, tab
 		rowsAppended++
 
 		// Flush if we've reached row limit OR bytes limit
-		if rowsAppended%flushInterval == 0 || bytesSinceFlush >= flushBytesLimit {
+		if rowsAppended%int64(flushInterval) == 0 || bytesSinceFlush >= uint64(flushBytesLimit) {
 			slog.Info(fmt.Sprintf("flushing appender for database %s, schema %s, table %s", database, schema, table), slog.Int64("rowsAppended", rowsAppended), slog.Uint64("bytesRead", bytesRead), slog.Uint64("bytesSinceFlush", bytesSinceFlush))
 			if err := appender.Flush(); err != nil {
 				return 0, 0, fmt.Errorf("failed to flush appender for database %s, schema %s, table %s: %w", database, schema, table, err)

--- a/internal/api/append.go
+++ b/internal/api/append.go
@@ -34,12 +34,20 @@ var (
 )
 
 func envIntDefault(key string, fallback int) int {
-	if v := os.Getenv(key); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			return n
-		}
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
 	}
-	return fallback
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		slog.Warn(fmt.Sprintf("Invalid value for environment variable %q: %q, using fallback %d", key, v, fallback))
+		return fallback
+	}
+	if n <= 0 {
+		slog.Warn(fmt.Sprintf("Non-positive value for environment variable %q: %q, using fallback %d", key, v, fallback))
+		return fallback
+	}
+	return n
 }
 
 func handleAppend(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/append_test.go
+++ b/internal/api/append_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -19,18 +20,19 @@ func TestEnvIntDefault(t *testing.T) {
 	const key = "DUCKTAPE_TEST_ENV_INT"
 
 	tests := []struct {
-		name     string
-		value    string
-		unset    bool
-		fallback int
-		want     int
+		name        string
+		value       string
+		unset       bool
+		fallback    int
+		want        int
+		wantWarnSub string // substring expected in slog warn output; empty means no warning expected
 	}{
 		{name: "unset returns fallback", unset: true, fallback: 100, want: 100},
 		{name: "empty returns fallback", value: "", fallback: 100, want: 100},
 		{name: "valid positive int", value: "32", fallback: 100, want: 32},
-		{name: "non-numeric returns fallback", value: "garbage", fallback: 100, want: 100},
-		{name: "zero returns fallback", value: "0", fallback: 100, want: 100},
-		{name: "negative returns fallback", value: "-5", fallback: 100, want: 100},
+		{name: "non-numeric returns fallback and warns", value: "garbage", fallback: 100, want: 100, wantWarnSub: "Invalid value"},
+		{name: "zero returns fallback and warns", value: "0", fallback: 100, want: 100, wantWarnSub: "Non-positive value"},
+		{name: "negative returns fallback and warns", value: "-5", fallback: 100, want: 100, wantWarnSub: "Non-positive value"},
 		{name: "large value accepted", value: "67108864", fallback: 100, want: 67108864},
 	}
 
@@ -41,8 +43,29 @@ func TestEnvIntDefault(t *testing.T) {
 			} else {
 				t.Setenv(key, tc.value)
 			}
+
+			// Capture slog output to assert warning behaviour.
+			var buf bytes.Buffer
+			prevDefault := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+			t.Cleanup(func() { slog.SetDefault(prevDefault) })
+
 			if got := envIntDefault(key, tc.fallback); got != tc.want {
 				t.Errorf("envIntDefault(%q, %d) with value=%q = %d, want %d", key, tc.fallback, tc.value, got, tc.want)
+			}
+
+			logged := buf.String()
+			if tc.wantWarnSub == "" {
+				if strings.Contains(logged, "level=WARN") {
+					t.Errorf("expected no warning, got log: %q", logged)
+				}
+			} else {
+				if !strings.Contains(logged, "level=WARN") {
+					t.Errorf("expected a WARN log containing %q, got: %q", tc.wantWarnSub, logged)
+				}
+				if !strings.Contains(logged, tc.wantWarnSub) {
+					t.Errorf("expected log to contain %q, got: %q", tc.wantWarnSub, logged)
+				}
 			}
 		})
 	}

--- a/internal/api/append_test.go
+++ b/internal/api/append_test.go
@@ -15,6 +15,39 @@ import (
 	"golang.org/x/net/http2/h2c"
 )
 
+func TestEnvIntDefault(t *testing.T) {
+	const key = "DUCKTAPE_TEST_ENV_INT"
+
+	tests := []struct {
+		name     string
+		value    string
+		unset    bool
+		fallback int
+		want     int
+	}{
+		{name: "unset returns fallback", unset: true, fallback: 100, want: 100},
+		{name: "empty returns fallback", value: "", fallback: 100, want: 100},
+		{name: "valid positive int", value: "32", fallback: 100, want: 32},
+		{name: "non-numeric returns fallback", value: "garbage", fallback: 100, want: 100},
+		{name: "zero returns fallback", value: "0", fallback: 100, want: 100},
+		{name: "negative returns fallback", value: "-5", fallback: 100, want: 100},
+		{name: "large value accepted", value: "67108864", fallback: 100, want: 67108864},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				os.Unsetenv(key)
+			} else {
+				t.Setenv(key, tc.value)
+			}
+			if got := envIntDefault(key, tc.fallback); got != tc.want {
+				t.Errorf("envIntDefault(%q, %d) with value=%q = %d, want %d", key, tc.fallback, tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAppend(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
The Appender flushes whenever its in-process buffer hits either a row count (`flushInterval`) or a byte size (`flushBytesLimit`). The previous 3 MiB byte default meant the Appender did many small round-trips per outer batch on remote destinations. Benchmarks against MotherDuck show raising the cap to 32 MiB delivers ~2.3-2.5x throughput on real customer-shaped workloads (5.7 KB and 20 KB row widths) with no observed failures. 64 MiB gives ~2.9-3.1x.

This change:
- Converts `flushInterval`, `flushBytesLimit`, and the per-line scanner buffer from compile-time constants to package-level vars seeded from env at startup.
- Raises the `flushBytesLimit` default from 3 MiB to 32 MiB.
- Adds `DUCKTAPE_FLUSH_BYTES`, `DUCKTAPE_FLUSH_ROWS`, `DUCKTAPE_SCANNER_BUFFER` for operators who want to override without rebuilding.
- Documents the new env vars in the README.
- Adds `TestEnvIntDefault` covering the env parser edge cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes ingestion buffering/flush behavior and raises the default buffered payload to 32MiB, which can increase per-stream memory usage and alter performance characteristics under load.
> 
> **Overview**
> Makes the NDJSON append path’s flush thresholds and per-line scanner buffer **configurable via environment variables**, replacing hard-coded limits.
> 
> Raises the default `flushBytesLimit` from **3MiB to 32MiB** and adds `DUCKTAPE_FLUSH_BYTES`, `DUCKTAPE_FLUSH_ROWS`, and `DUCKTAPE_SCANNER_BUFFER`, with warnings+fallbacks for invalid values plus a new `TestEnvIntDefault`. Documentation in `README.md` is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ba7f78a3b8f3bfedfe40399ae04444599d30762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->