### PR TITLE
[DSN] Only load MotherDuck settings if motherduck extension is explicitly loaded

### DIFF
--- a/internal/utils/connector.go
+++ b/internal/utils/connector.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 	"os"
 	"log/slog"
@@ -60,6 +61,17 @@ func NewConnector(ctx context.Context, dsn string) (*Connector, error) {
 
 	targetDB := strings.TrimPrefix(target, "md:")
 
+	var mdSettings []string
+	for key := range params {
+		if !strings.HasPrefix(key, "motherduck_") {
+			continue
+		}
+		value := params.Get(key)
+		params.Del(key)
+		mdSettings = append(mdSettings, fmt.Sprintf("SET %s='%s'", key, escapeSQLString(value)))
+	}
+	sort.Strings(mdSettings)
+
 	encodedParams := params.Encode()
 	var inMemoryDSN string
 	if encodedParams != "" {
@@ -73,8 +85,9 @@ func NewConnector(ctx context.Context, dsn string) (*Connector, error) {
 			`INSTALL motherduck`,
 			`LOAD motherduck`,
 			fmt.Sprintf("SET motherduck_token='%s'", escapeSQLString(tokens[0])),
-			`ATTACH 'md:'`,
 		}
+		bootQueries = append(bootQueries, mdSettings...)
+		bootQueries = append(bootQueries, `ATTACH 'md:'`)
 		if targetDB != "" {
 			bootQueries = append(bootQueries, fmt.Sprintf("USE '%s'", escapeSQLString(targetDB)))
 		}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes MotherDuck connection bootstrap order and which DSN keys affect DuckDB vs MotherDuck; mis-ordered or invalid settings could break existing MotherDuck URLs.
> 
> **Overview**
> When a DSN includes `motherduck_token`, **MotherDuck-specific query parameters** (`motherduck_*`, other than the token) are no longer left on the in-memory DuckDB DSN. They are stripped from the URL, turned into `SET motherduck_*='...'` boot queries (with SQL escaping), **sorted for stable order**, and run after `LOAD motherduck` / token setup and **before** `ATTACH 'md:'`.
> 
> Non-`motherduck_` DSN options still apply only to the `:memory:` connector params, so MotherDuck settings apply only on the explicit MotherDuck bootstrap path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b45eedfa8f8a58b5374b158039575b4c93cecee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->