### PR TITLE
feat: add support for HTTP Basic Authentication

### DIFF
--- a/api/pkg/ducktape/client.go
+++ b/api/pkg/ducktape/client.go
@@ -98,6 +98,10 @@ func (c *Client) Execute(
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to execute: %s", resp.Status)
+	}
+
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
@@ -135,6 +139,10 @@ func (c *Client) Query(
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to query: %s", resp.Status)
+	}
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -206,6 +214,10 @@ func (c *Client) Append(
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to append: %s", resp.Status)
+	}
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/api/pkg/ducktape/client.go
+++ b/api/pkg/ducktape/client.go
@@ -17,6 +17,8 @@ import (
 type Client struct {
 	baseURL    string
 	httpClient *http.Client
+	username   string
+	password   string
 }
 
 func NewClient(baseURL string) *Client {
@@ -30,6 +32,12 @@ func NewClient(baseURL string) *Client {
 	return &Client{baseURL: baseURL, httpClient: &http.Client{Transport: tr}}
 }
 
+// SetBasicAuth sets the username and password for HTTP basic authentication.
+func (c *Client) SetBasicAuth(username, password string) {
+	c.username = username
+	c.password = password
+}
+
 func (c *Client) Ping(
 	ctx context.Context,
 	connectionString string,
@@ -38,6 +46,10 @@ func (c *Client) Ping(
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return err
+	}
+
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
 	}
 
 	req.Header.Set(DuckDBConnectionStringHeader, connectionString)
@@ -71,6 +83,10 @@ func (c *Client) Execute(
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
+	}
+
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -107,6 +123,10 @@ func (c *Client) Query(
 		return nil, err
 	}
 
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(DuckDBConnectionStringHeader, connectionString)
 
@@ -137,6 +157,10 @@ func (c *Client) Append(
 	req, err := http.NewRequestWithContext(ctx, "POST", url, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
 	}
 
 	req.Header.Set("Content-Type", "application/octet-stream")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,6 +56,14 @@ func main() {
 	})
 	slog.SetDefault(logger)
 
+	username := os.Getenv("DUCKTAPE_USERNAME")
+	password := os.Getenv("DUCKTAPE_PASSWORD")
+	if (username != "" && password == "") || (username == "" && password != "") {
+		slog.Warn("Only one of DUCKTAPE_USERNAME or DUCKTAPE_PASSWORD is set. Basic authentication is disabled because both must be set.")
+	} else if username != "" && password != "" {
+		slog.Info("Basic authentication is enabled.")
+	}
+
 	mux := http.NewServeMux()
 
 	api.RegisterApiRoutes(mux)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,10 +58,10 @@ func main() {
 
 	username := os.Getenv("DUCKTAPE_USERNAME")
 	password := os.Getenv("DUCKTAPE_PASSWORD")
-	if (username != "" && password == "") || (username == "" && password != "") {
-		slog.Warn("Only one of DUCKTAPE_USERNAME or DUCKTAPE_PASSWORD is set. Basic authentication is disabled because both must be set.")
-	} else if username != "" && password != "" {
+	if username != "" && password != "" {
 		slog.Info("Basic authentication is enabled.")
+	} else if username != "" || password != "" {
+		slog.Warn("Basic authentication is disabled because both DUCKTAPE_USERNAME and DUCKTAPE_PASSWORD must be non-empty.")
 	}
 
 	mux := http.NewServeMux()

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -117,7 +117,7 @@ func TestBasicAuth(t *testing.T) {
 
 	// 1. Request without Basic Auth should fail
 	ctx := context.Background()
-	err := client.Ping(ctx, "test_auth.db")
+	err := client.Ping(ctx, ":memory:")
 	if err == nil {
 		t.Fatal("expected unauthorized error, got nil")
 	}
@@ -127,7 +127,7 @@ func TestBasicAuth(t *testing.T) {
 
 	// 2. Request with incorrect Basic Auth should fail
 	client.SetBasicAuth("admin", "wrong_password")
-	err = client.Ping(ctx, "test_auth.db")
+	err = client.Ping(ctx, ":memory:")
 	if err == nil {
 		t.Fatal("expected unauthorized error with wrong password, got nil")
 	}
@@ -135,12 +135,10 @@ func TestBasicAuth(t *testing.T) {
 		t.Fatalf("expected 401 error with wrong password, got: %v", err)
 	}
 
-	// 3. Request with correct Basic Auth should succeed (or return standard response)
+	// 3. Request with correct Basic Auth should succeed
 	client.SetBasicAuth("admin", "secret")
-	err = client.Ping(ctx, "test_auth.db")
-	// Since test_auth.db might not exist or ping might fail due to other reasons,
-	// let's check that we don't get a 401 Unauthorized.
-	if err != nil && strings.Contains(err.Error(), "401") {
-		t.Fatalf("expected authorized, but got: %v", err)
+	err = client.Ping(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
 	}
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2,11 +2,16 @@ package api
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/artie-labs/ducktape/api/pkg/ducktape"
 	_ "github.com/duckdb/duckdb-go/v2"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 func TestQueryExecuteIntegration(t *testing.T) {
@@ -93,4 +98,49 @@ func TestContextCancellation(t *testing.T) {
 			Query: "SELECT 1",
 		})
 	})
+}
+
+func TestBasicAuth(t *testing.T) {
+	// Set environment variables for Basic Auth
+	t.Setenv("DUCKTAPE_USERNAME", "admin")
+	t.Setenv("DUCKTAPE_PASSWORD", "secret")
+
+	mux := http.NewServeMux()
+	RegisterApiRoutes(mux)
+
+	// Create a test server with h2c support
+	h2cHandler := h2c.NewHandler(mux, &http2.Server{})
+	server := httptest.NewServer(h2cHandler)
+	defer server.Close()
+
+	client := ducktape.NewClient(server.URL)
+
+	// 1. Request without Basic Auth should fail
+	ctx := context.Background()
+	err := client.Ping(ctx, "test_auth.db")
+	if err == nil {
+		t.Fatal("expected unauthorized error, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("expected 401 error, got: %v", err)
+	}
+
+	// 2. Request with incorrect Basic Auth should fail
+	client.SetBasicAuth("admin", "wrong_password")
+	err = client.Ping(ctx, "test_auth.db")
+	if err == nil {
+		t.Fatal("expected unauthorized error with wrong password, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("expected 401 error with wrong password, got: %v", err)
+	}
+
+	// 3. Request with correct Basic Auth should succeed (or return standard response)
+	client.SetBasicAuth("admin", "secret")
+	err = client.Ping(ctx, "test_auth.db")
+	// Since test_auth.db might not exist or ping might fail due to other reasons,
+	// let's check that we don't get a 401 Unauthorized.
+	if err != nil && strings.Contains(err.Error(), "401") {
+		t.Fatalf("expected authorized, but got: %v", err)
+	}
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	stdjson "encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -140,5 +142,83 @@ func TestBasicAuth(t *testing.T) {
 	err = client.Ping(ctx, ":memory:")
 	if err != nil {
 		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	// Helper functions for Marshal and Unmarshal
+	marshalExec := func(r ducktape.ExecuteRequest) ([]byte, error) {
+		return stdjson.Marshal(r)
+	}
+	unmarshalExec := func(r []byte) (*ducktape.ExecuteResponse, error) {
+		var resp ducktape.ExecuteResponse
+		if err := stdjson.Unmarshal(r, &resp); err != nil {
+			return nil, err
+		}
+		return &resp, nil
+	}
+	marshalQuery := func(r ducktape.QueryRequest) ([]byte, error) {
+		return stdjson.Marshal(r)
+	}
+	unmarshalQuery := func(r []byte) (*ducktape.QueryResponse, error) {
+		var resp ducktape.QueryResponse
+		if err := stdjson.Unmarshal(r, &resp); err != nil {
+			return nil, err
+		}
+		return &resp, nil
+	}
+
+	// 4. POST route (Execute) without Basic Auth should fail
+	unauthenticatedClient := ducktape.NewClient(server.URL)
+	_, err = unauthenticatedClient.Execute(ctx, ducktape.ExecuteRequest{
+		Statements: []ducktape.ExecuteStatement{
+			{Query: "SELECT 1"},
+		},
+	}, ":memory:", marshalExec, unmarshalExec)
+	if err == nil {
+		t.Fatal("expected unauthorized error for Execute, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("expected 401 error for Execute, got: %v", err)
+	}
+
+	// 5. POST route (Query) without Basic Auth should fail
+	_, err = unauthenticatedClient.Query(ctx, ducktape.QueryRequest{
+		Query: "SELECT 1",
+	}, ":memory:", marshalQuery, unmarshalQuery)
+	if err == nil {
+		t.Fatal("expected unauthorized error for Query, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("expected 401 error for Query, got: %v", err)
+	}
+
+	// 6. POST routes with correct Basic Auth should succeed
+	client.SetBasicAuth("admin", "secret")
+	execResp, err := client.Execute(ctx, ducktape.ExecuteRequest{
+		Statements: []ducktape.ExecuteStatement{
+			{Query: "CREATE TABLE test_auth (id INTEGER)"},
+		},
+	}, ":memory:", marshalExec, unmarshalExec)
+	if err != nil {
+		t.Fatalf("expected Execute to succeed, got error: %v", err)
+	}
+	if execResp.Error != nil {
+		t.Fatalf("expected Execute response with no error, got: %s", *execResp.Error)
+	}
+
+	queryResp, err := client.Query(ctx, ducktape.QueryRequest{
+		Query: "SELECT 1 as val",
+	}, ":memory:", marshalQuery, unmarshalQuery)
+	if err != nil {
+		t.Fatalf("expected Query to succeed, got error: %v", err)
+	}
+	if queryResp.Error != nil {
+		t.Fatalf("expected Query response with no error, got: %s", *queryResp.Error)
+	}
+	if len(queryResp.Rows) != 1 {
+		t.Fatalf("unexpected query result length: %d", len(queryResp.Rows))
+	}
+	val := queryResp.Rows[0]["val"]
+	if fmt.Sprintf("%v", val) != "1" {
+		t.Fatalf("unexpected query result value: %v", val)
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"sync/atomic"
 
 	jsoniter "github.com/json-iterator/go"
@@ -37,10 +38,32 @@ func RegisterHealthCheckRoutes(mux *http.ServeMux) {
 }
 
 func RegisterApiRoutes(mux *http.ServeMux) {
-	mux.HandleFunc(fmt.Sprintf("POST %s", ducktape.ExecuteRoute), handleExecute)
-	mux.HandleFunc(fmt.Sprintf("POST %s", ducktape.QueryRoute), handleQuery)
-	mux.HandleFunc(fmt.Sprintf("POST %s", ducktape.AppendRoute), handleAppend)
-	mux.HandleFunc(fmt.Sprintf("GET %s", ducktape.PingRoute), handlePing)
+	username := os.Getenv("DUCKTAPE_USERNAME")
+	password := os.Getenv("DUCKTAPE_PASSWORD")
+
+	var wrap func(http.HandlerFunc) http.HandlerFunc
+	if username != "" && password != "" {
+		wrap = func(next http.HandlerFunc) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				u, p, ok := r.BasicAuth()
+				if !ok || u != username || p != password {
+					w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
+					http.Error(w, "Unauthorized", http.StatusUnauthorized)
+					return
+				}
+				next(w, r)
+			}
+		}
+	} else {
+		wrap = func(next http.HandlerFunc) http.HandlerFunc {
+			return next
+		}
+	}
+
+	mux.HandleFunc(fmt.Sprintf("POST %s", ducktape.ExecuteRoute), wrap(handleExecute))
+	mux.HandleFunc(fmt.Sprintf("POST %s", ducktape.QueryRoute), wrap(handleQuery))
+	mux.HandleFunc(fmt.Sprintf("POST %s", ducktape.AppendRoute), wrap(handleAppend))
+	mux.HandleFunc(fmt.Sprintf("GET %s", ducktape.PingRoute), wrap(handlePing))
 }
 
 func getRequestBody[T any](r *http.Request) (T, error) {


### PR DESCRIPTION
### Summary

This PR adds support for HTTP Basic Authentication to `ducktape` as proposed in #35.

Fix #35 

It is highly beneficial for deploying `ducktape` in public or cloud environments (e.g., Digital Ocean App Platform, fly.io, etc.) where fine-grained firewall rules might not be supported or are tedious to configure.

### Changes

1. **Server Configuration**:
   - Added checking for `DUCKTAPE_USERNAME` and `DUCKTAPE_PASSWORD` environment variables.
   - If both are set, the API routes (`/api/execute`, `/api/query`, `/api/append`, `/api/ping`) are wrapped in a Basic Authentication middleware.
   - Health and readiness endpoints (`/health` and `/ready`) remain unprotected so that load balancers and deployment platforms can continue to perform health checks seamlessly.
   - Added startup logs to inform the user whether Basic Authentication is enabled or disabled (with warnings if only one of the environment variables is set).

2. **Go Client**:
   - Added `SetBasicAuth(username, password string)` to the `Client` struct.
   - When set, all requests (`Ping`, `Execute`, `Query`, `Append`) automatically include the HTTP Basic Authentication headers.

3. **Tests**:
   - Added comprehensive integration tests (`TestBasicAuth`) in `internal/api/api_test.go` verifying:
     - Unauthenticated requests fail with `401 Unauthorized`.
     - Requests with incorrect credentials fail with `401 Unauthorized`.
     - Requests with correct credentials succeed.
