### PR TITLE
chore: add guarded make prune target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,28 @@ release:
 	docker manifest push artielabs/ducktape:$$TAG
 	@echo ""
 	@echo "Release complete!"
+
+.PHONY: prune
+prune:
+	@current=$$(git branch --show-current) && \
+	if [ -z "$$current" ]; then \
+		echo "Error: in detached HEAD state — refusing to prune (no branch is protected)."; \
+		exit 1; \
+	fi && \
+	branches=$$(git branch | grep -v "^\\* " | sed 's/^  //') && \
+	if [ -z "$$branches" ]; then \
+		echo "No other local branches to delete."; \
+	else \
+		echo "This will delete the following local branches:" && \
+		echo "$$branches" && \
+		echo "" && \
+		echo "Current branch '$$current' will be kept." && \
+		echo "" && \
+		printf "Are you sure? (y/N) " && \
+		read confirm && \
+		if [ "$$confirm" = "y" ] || [ "$$confirm" = "Y" ]; then \
+			echo "$$branches" | xargs git branch -d; \
+		else \
+			echo "Aborted."; \
+		fi \
+	fi


### PR DESCRIPTION
Adds the dataplane-api-style guarded local-branch prune target. It refuses detached HEAD and requires confirmation before deletion.

Tested: `make -n prune`; `printf 'n\n' | make prune`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only developer workflow helper; no runtime, security, or production code changes.
> 
> **Overview**
> Adds a **`make prune`** target to the Makefile for cleaning up **other local git branches** while keeping the current branch.
> 
> **Guards:** refuses to run on **detached HEAD** (no branch to protect), lists branches to delete, and requires **y/Y** confirmation before running `git branch -d`. If there are no other branches, it prints a short message and exits without prompting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6923de58d0ba67a267462fdfb081d2992ba44417. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->